### PR TITLE
Basic introspection support

### DIFF
--- a/lib/Sub/Exporter.pm
+++ b/lib/Sub/Exporter.pm
@@ -7,6 +7,7 @@ use Carp ();
 use Data::OptList ();
 use Params::Util ();
 use Sub::Install 0.92 ();
+use Sub::Exporter::Import;
 
 =head1 NAME
 
@@ -754,6 +755,8 @@ sub build_exporter {
       $to_import,
     );
   };
+
+  Sub::Exporter::Import->new( $import, $config );
 
   return $import;
 }

--- a/lib/Sub/Exporter/Import.pm
+++ b/lib/Sub/Exporter/Import.pm
@@ -1,0 +1,25 @@
+package Sub::Exporter::Import;
+use strict;
+use warnings;
+
+our %DATA;
+
+sub new {
+    my $class = shift;
+    my ( $import, $config ) = @_;
+    my $self = bless( $import );
+    $DATA{$self} = $config;
+    return $self;
+}
+
+sub config {
+    my $self = shift;
+    return $DATA{ $self };
+}
+
+sub DESTROY {
+    my $self = shift;
+    delete $DATA{$self};
+}
+
+1;

--- a/t/introspection.t
+++ b/t/introspection.t
@@ -1,0 +1,28 @@
+#!perl -T
+use strict;
+use warnings;
+
+=head1 TEST PURPOSE
+
+This tests the ability to introspect a Sub::Exporter based class.
+
+=cut
+
+use Test::More tests => 1;
+
+{
+    package An::Exporter;
+    use strict;
+    use warnings;
+    use Sub::Exporter -setup => {
+        exports => [ 'a' ]
+    };
+
+    sub a { 'a' }
+}
+
+is_deeply(
+    An::Exporter->can('import')->config->{exports},
+    { a => undef },
+    "Accessed the config data"
+);


### PR DESCRIPTION
I find myself needing to access the configuration details of an exporter that uses Sub::Exporter. This is a case where I may not know what the class I am accessing exports.

This will add the ability to ask an import() method generated by Sub::Exporter what $config it was created with. This can also be done with PadWalker, but thats less than ideal.

Thank you for your time.
