### PR TITLE
fix minor mistakes in Cookbook

### DIFF
--- a/lib/Sub/Exporter/Cookbook.pod
+++ b/lib/Sub/Exporter/Cookbook.pod
@@ -1,4 +1,3 @@
-
 =head1 NAME
 
 =cut
@@ -25,7 +24,7 @@ L<Sub::Exporter::Util>, a method can be exported with the invocant built in.
 
   package Object::Strenuous;
 
-  use Sub::Exporter::Util;
+  use Sub::Exporter::Util 'curry_method';
   use Sub::Exporter -setup => {
     exports => [ objection => curry_method('new') ],
   };
@@ -50,11 +49,12 @@ Finally, since the invocant can be an object, you can write something like
 this:
 
   package Cypher;
+  use Sub::Exporter::Util 'curry_method';
   use Sub::Exporter -setup => {
     exports => [ encypher => curry_method ],
   };
 
-with the expectation that C<import> will be called an instantiated Cypher
+with the expectation that C<import> will be called on an instantiated Cypher
 object:
 
   BEGIN {


### PR DESCRIPTION
The cookbook recipes using 'curry_method' currently don't work, since Sub::Exporter::Util doesn't export 'curry_method' by default.

This patch makes the recipes explicitly import 'curry_method'. As a bonus, it fixes a typo.
