### PR TITLE
t/real-export-setup.t - fix broken test in SETUPALT

### DIFF
--- a/t/real-export-setup.t
+++ b/t/real-export-setup.t
@@ -136,6 +136,9 @@ for my $iteration (1..2) {
 
 {
   package Test::SubExporter::SETUPALT;
+  use Exporter qw(import);
+  our %EXPORT_TAGS = ( "all" => [] );
+
   use Sub::Exporter -setup => {
     -as      => 'alternimport',
     exports => [ qw(Y) ],


### PR DESCRIPTION
This test calls Test::SubExport::SETUPALT->import(":all") but there is not such method defined, and only works because Perl special cases the handling of a missing import() method to not throw an exception, thus making such calls a no-op. This no-op behavior simulates what would happen if there was a UNIVERSAL::import() method that does nothing.

In 5.39.0 Perl added a UNIVERSAL::import() method which throws an error if it is passed an argument, as the argument will be ignored, and this pattern is usually indicitive of a usage error, especially on case insensitive file systems. This then breaks this test.

This patch could also simply remove the call to import() but that would make the code look a bit odd. Instead we use the import function provided by Exporter, and define an "all" tag with no symbols in it.

See: https://github.com/Perl/perl5/issues/21269

Happy Birthday. 